### PR TITLE
feat/adding additional commands on commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gitgit consolidates the following commands into one easy to remember song:
 
 `sudo ./setup.sh`
 
-Be sure to leave the repo clone!  To update, see the udpate section:
+Be sure to leave the repo cloned!  To update, see the udpate section:
 
 # Update
 Navigate to the cloned repo: `cd gitgit`

--- a/gitgit
+++ b/gitgit
@@ -27,6 +27,8 @@ THEBRANCH=$(git branch | sed 's/ //g' | grep -E "^(main|master)$" | head -1)
 
 additional_commands()
 {
+	echo "Found additional commands. Running:"
+	echo "$GITGITCMD"
 	"$GITGITCMD"
 }
 
@@ -50,7 +52,7 @@ commit()
 	then 
 		additional_commands
 	fi
-	
+
 	echo "On Branch: $TREEBRANCH"
 	git add .
 

--- a/gitgit
+++ b/gitgit
@@ -53,6 +53,7 @@ commit()
 		additional_commands
 	else
 		echo skipping...
+		echo "$GITGITCMD"
 	fi
 
 	echo "On Branch: $TREEBRANCH"

--- a/gitgit
+++ b/gitgit
@@ -51,6 +51,8 @@ commit()
 	if [ ! -z "$GITGITCMD" ]
 	then 
 		additional_commands
+	else
+		echo skipping...
 	fi
 
 	echo "On Branch: $TREEBRANCH"

--- a/gitgit
+++ b/gitgit
@@ -25,6 +25,11 @@ fi
 TREEBRANCH=$(git branch --show-current)
 THEBRANCH=$(git branch | sed 's/ //g' | grep -E "^(main|master)$" | head -1)
 
+additional_commands()
+{
+	"$GITGITCMD"
+}
+
 branchit()
 {
 	if [[ "$NB" =~ ^[-A-Za-z0-9]+$ ]]
@@ -41,6 +46,11 @@ branchit()
 
 commit()
 {
+	if [ ! -z "$GITGITCMD" ]
+	then 
+		additional_commands
+	fi
+	
 	echo "On Branch: $TREEBRANCH"
 	git add .
 

--- a/gitgit
+++ b/gitgit
@@ -52,8 +52,7 @@ commit()
 	then 
 		additional_commands
 	else
-		echo skipping...
-		echo "$GITGITCMD"
+		echo "No additional commands found... continuing."
 	fi
 
 	echo "On Branch: $TREEBRANCH"


### PR DESCRIPTION
There are times additional commands need to be run before a commit.  You can now populate and export GITGITCMD with commands that need to be run before each time you commit.

Example:

```
export GITGITCMD='terraform fmt -recursive; black .'
```