### PR TITLE
adding default branch name

### DIFF
--- a/gitgit
+++ b/gitgit
@@ -135,6 +135,10 @@ then
 			if [[ "$ANS" =~ ^(y|Y)$ ]]
 			then
 				read -p "Enter a new branch name (letters, numbers and dashes only): " NB
+				if [[ -z "$NB" ]]
+				then
+					NB=${1// /-}
+				fi
 			else
 				echo "Leaving changes on the main/master branch alone and exiting!"
 				exit 1


### PR DESCRIPTION
to make things esier, allow the user to not pass a branch name and instead use the initial commit message.

current state:

```
➜ gitgit (main) ✔ ./gitgit 'adding another change'
You are on the main/master branch, HOWEVER changes have been detected!
Would you like to create a new branch to move the changes to? (y/n): y
Enter a new branch name (letters, numbers and dashes only): custom-named-branch
Creating new branch 'custom-named-branch' and migrating changes to this new feature branch.
```

new feature:

```
➜ gitgit (main) ✗ ./gitgit 'adding default branch name'
You are on the main/master branch, HOWEVER changes have been detected!
Would you like to create a new branch to move the changes to? (y/n): y
Enter a new branch name (letters, numbers and dashes only): 
Creating new branch 'adding-default-branch-name' and migrating changes to this new feature branch.
```