### PR TITLE
default-new-branch

### DIFF
--- a/gitgit
+++ b/gitgit
@@ -132,7 +132,7 @@ then
 			NB="$2"
 		else
 			read -p "Would you like to create a new branch to move the changes to? (y/n): " ANS
-			if [[ "$ANS" =~ ^(y|Y)$ ]]
+			if [[ "$ANS" =~ ^(y|Y|)$ ]]
 			then
 				read -p "Enter a new branch name or leave blank to use the commit message: " NB
 				if [[ -z "$NB" ]]


### PR DESCRIPTION
when asking users if they want to branch off for their changes, no response should default to creating said branch.